### PR TITLE
feat: Disable row selection on click

### DIFF
--- a/src/web/src/features/groups/GroupsTable.tsx
+++ b/src/web/src/features/groups/GroupsTable.tsx
@@ -49,6 +49,7 @@ const GroupsTable = () => {
       columns={columns}
       rows={data?.value || []}
       onPaginationModelChange={paginationModelChange}
+      disableRowSelectionOnClick
     />
   );
 };


### PR DESCRIPTION
When clicking the groups table it will select the row. However, there are no selection actions therefore i disabled the row selection for now.