### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -25,6 +25,8 @@ jobs:
 
   CI:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./src/web
@@ -57,6 +59,9 @@ jobs:
 
   BuildContainersForPR_Linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
@@ -69,6 +74,9 @@ jobs:
 
   BuildLinux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LuukLabs/KDVManager/security/code-scanning/13](https://github.com/LuukLabs/KDVManager/security/code-scanning/13)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for each job. For example:
- The `CI` job primarily checks out code and runs tests, so it only needs `contents: read`.
- The `BuildContainersForPR_Linux` and `BuildLinux` jobs interact with secrets and push containers, so they might need additional permissions like `contents: read` and `packages: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or individually for each job. In this case, we will add specific permissions for each job to ensure granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
