### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduling-migrator.yml
+++ b/.github/workflows/scheduling-migrator.yml
@@ -1,5 +1,8 @@
 name: scheduling-migrator
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LuukLabs/KDVManager/security/code-scanning/11](https://github.com/LuukLabs/KDVManager/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out code and interacting with registry credentials, the `contents: read` permission is sufficient for most tasks. If specific write permissions are required (e.g., for pull requests), they should be explicitly defined.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to tailor permissions for specific tasks. In this case, adding it at the root level is more efficient since both jobs likely require similar permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
